### PR TITLE
feat: add autocomplete input

### DIFF
--- a/src/components/composer-controls.tsx
+++ b/src/components/composer-controls.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { AutocompleteInput } from '@/components/ui/autocomplete-input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Plus, Trash2, X, UserPlus, BookUser, Check, RefreshCcw } from 'lucide-react';
@@ -80,8 +81,9 @@ export function ComposerControls({
           {activeTicket && (
             <div className="space-y-2">
               <Label htmlFor="ticket-name">Name</Label>
-              <Input
+              <AutocompleteInput
                 id="ticket-name"
+                storageKey="ticket-name"
                 value={activeTicket.name}
                 onChange={(e) => onUpdateActiveTicket({ name: e.target.value })}
                 className="w-full bg-background/50"
@@ -175,8 +177,9 @@ export function ComposerControls({
               <div className="space-y-4">
                 <div className="space-y-2">
                   <Label htmlFor="new-contact-name">Name</Label>
-                  <Input 
+                  <AutocompleteInput
                     id="new-contact-name"
+                    storageKey="contact-name"
                     placeholder="John Doe"
                     value={newContactName}
                     onChange={(e) => setNewContactName(e.target.value)}

--- a/src/components/ui/autocomplete-input.tsx
+++ b/src/components/ui/autocomplete-input.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import { Input } from "./input";
+
+interface AutocompleteInputProps extends React.ComponentProps<typeof Input> {
+  /**
+   * A unique key used to persist suggestions in localStorage
+   */
+  storageKey: string;
+}
+
+export function AutocompleteInput({
+  storageKey,
+  id,
+  onBlur,
+  ...props
+}: AutocompleteInputProps) {
+  const listId = React.useMemo(() => `${id || storageKey}-list`, [id, storageKey]);
+  const [suggestions, setSuggestions] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    try {
+      const stored = localStorage.getItem(`autocomplete:${storageKey}`);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          setSuggestions(parsed);
+        }
+      }
+    } catch (error) {
+      console.error("Failed to load autocomplete suggestions", error);
+    }
+  }, [storageKey]);
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    onBlur?.(e);
+    const value = e.target.value.trim();
+    if (!value) return;
+
+    setSuggestions((prev) => {
+      if (prev.includes(value)) return prev;
+      const updated = [...prev, value];
+      try {
+        localStorage.setItem(
+          `autocomplete:${storageKey}`,
+          JSON.stringify(updated)
+        );
+      } catch (error) {
+        console.error("Failed to save autocomplete suggestions", error);
+      }
+      return updated;
+    });
+  };
+
+  return (
+    <>
+      <Input {...props} id={id} list={listId} onBlur={handleBlur} />
+      {suggestions.length > 0 && (
+        <datalist id={listId}>
+          {suggestions.map((s) => (
+            <option key={s} value={s} />
+          ))}
+        </datalist>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable AutocompleteInput component that stores suggestions in localStorage
- use autocomplete for ticket name and contact name fields

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck` *(fails: Object literal may only specify known properties, and 'allowedDevOrigins' does not exist in type 'ExperimentalConfig')*


------
https://chatgpt.com/codex/tasks/task_e_689dee8822dc8325b551c798c35f8fc0