### PR TITLE
Use nullish coalescing for addText coordinates

### DIFF
--- a/src/app/edit/[compositionId]/page.tsx
+++ b/src/app/edit/[compositionId]/page.tsx
@@ -152,8 +152,8 @@ export default function EditPage({ params }: EditPageProps) {
     const newText: TextElement = {
       id: nanoid(),
       text,
-      x: options?.x || canvas.width / 4,
-      y: options?.y || canvas.height / 4,
+      x: options?.x ?? canvas.width / 4,
+      y: options?.y ?? canvas.height / 4,
       fontSize: 48,
       fontFamily: 'Inter',
       color: '#000000',


### PR DESCRIPTION
## Summary
- ensure `addText` respects 0 for x/y by using nullish coalescing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt for ESLint config)*
- `npm run typecheck` *(fails: unknown property 'allowedDevOrigins')*
- `node - <<'NODE'...`

------
https://chatgpt.com/codex/tasks/task_e_689de76237348325a2dde2186e3fa0a4