### PR TITLE
docs: correct fileoverview tag in suggest-quote flow

### DIFF
--- a/src/ai/flows/suggest-quote.ts
+++ b/src/ai/flows/suggest-quote.ts
@@ -3,7 +3,7 @@
 'use server';
 
 /**
- * @fileOverview This file defines a Genkit flow for suggesting quotes based on a given topic.
+ * @fileoverview This file defines a Genkit flow for suggesting quotes based on a given topic.
  *
  * - `suggestQuote` - An exported function that takes a topic as input and returns a suggested quote.
  * - `SuggestQuoteInput` - The input type for the `suggestQuote` function, which is a string representing the topic.


### PR DESCRIPTION
## Summary
- fix JSDoc tag in `suggest-quote` flow to use standard `@fileoverview`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: Object literal may only specify known properties)*

------
https://chatgpt.com/codex/tasks/task_e_689de756f6b883259d41a1619db4c2a4